### PR TITLE
Bump j4rs to 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thread-support = ["crossbeam-channel", "serde_json"]
 [dependencies]
 crossbeam-channel = { version = "^0.3.8", optional = true }
 failure = "^0.1.5"
-j4rs = "^0.5.1"
+j4rs = "^0.11.2"
 serde = "^1.0.0"
 serde_derive = "^1.0.0"
 serde_json = { version = "^1.0.26", optional = true }

--- a/src/base.rs
+++ b/src/base.rs
@@ -4,6 +4,7 @@ use j4rs::InvocationArg;
 use j4rs::Jvm;
 use serde::de::DeserializeOwned;
 
+use std::convert::TryFrom;
 use super::ErrorKind;
 use super::MBeanInfo;
 use super::Result;
@@ -37,11 +38,11 @@ impl MBeanAddress {
                     "service:jmx:rmi://{}/jndi/rmi://{}/jmxrmi",
                     address, address
                 );
-                jvm.create_instance(JMX_SERVICE_URL, &vec![InvocationArg::from(url)])
+                jvm.create_instance(JMX_SERVICE_URL, &vec![InvocationArg::try_from(url)?])
                     .with_context(|_| ErrorKind::JavaCreateInstance(JMX_SERVICE_URL))?
             },
             MBeanAddress::ServiceUrl(url) => jvm.create_instance(
-                JMX_SERVICE_URL, &vec![InvocationArg::from(url)]
+                JMX_SERVICE_URL, &vec![InvocationArg::try_from(url)?]
             ).with_context(|_| ErrorKind::JavaCreateInstance(JMX_SERVICE_URL))?,
         };
         Ok(instance)

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,7 @@ pub enum ErrorKind {
     #[fail(display = "could not invoke instance method '{}.{}'", _0, _1)]
     JavaInvoke(String, &'static str),
 
-    #[fail(display = "could not parse invocation arg '{}'", _0)]
+    #[fail(display = "j4rs thrown an error '{}'", _0)]
     J4RsError(J4RsError),
 
     #[fail(display = "could not invoke static method '{}.{}'", _0, _1)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use failure::Backtrace;
 use failure::Context;
 use failure::Fail;
+use j4rs::errors::J4RsError;
 
 
 /// Error information returned by functions in case of errors.
@@ -43,6 +44,12 @@ impl From<ErrorKind> for Error {
     }
 }
 
+impl From<J4RsError> for Error {
+    fn from(e: J4RsError) -> Error {
+        Error(Context::new(ErrorKind::J4RsError(e)))
+    }
+}
+
 
 /// Exhaustive list of possible errors emitted by this crate.
 #[derive(Debug, Fail)]
@@ -58,6 +65,9 @@ pub enum ErrorKind {
 
     #[fail(display = "could not invoke instance method '{}.{}'", _0, _1)]
     JavaInvoke(String, &'static str),
+
+    #[fail(display = "could not parse invocation arg '{}'", _0)]
+    J4RsError(J4RsError),
 
     #[fail(display = "could not invoke static method '{}.{}'", _0, _1)]
     JavaInvokeStatic(&'static str, &'static str),

--- a/src/mbean_client.rs
+++ b/src/mbean_client.rs
@@ -15,6 +15,8 @@ use super::constants::JMX_CONNECTOR_FACTORY;
 use super::constants::JMX_OBJECT_NAME;
 use super::constants::JMX_QUERY_EXP;
 
+use std::convert::TryFrom;
+
 use super::util::to_vec;
 
 
@@ -85,11 +87,11 @@ impl MBeanClientTrait for MBeanClient {
               T: DeserializeOwned,
     {
         let object_name = self.jvm.create_instance(
-            JMX_OBJECT_NAME, &vec![InvocationArg::from(mbean.into())]
+            JMX_OBJECT_NAME, &vec![InvocationArg::try_from(mbean.into())?]
         ).with_context(|_| ErrorKind::JavaCreateInstance(JMX_OBJECT_NAME))?;
         let value = self.jvm.invoke(
             &self.connection, "getAttribute",
-            &vec![InvocationArg::from(object_name), InvocationArg::from(attribute.into())]
+            &vec![InvocationArg::from(object_name), InvocationArg::try_from(attribute.into())?]
         ).with_context(
             |_| ErrorKind::JavaInvoke(self.connection.class_name().to_string(), "getAttribute")
         )?;
@@ -101,7 +103,7 @@ impl MBeanClientTrait for MBeanClient {
         where S: Into<String>,
     {
         let object_name = self.jvm.create_instance(
-            JMX_OBJECT_NAME, &vec![InvocationArg::from(mbean.into())]
+            JMX_OBJECT_NAME, &vec![InvocationArg::try_from(mbean.into())?]
         ).with_context(|_| ErrorKind::JavaCreateInstance(JMX_OBJECT_NAME))?;
         let info = self.jvm.invoke(
             &self.connection, "getMBeanInfo",
@@ -117,10 +119,10 @@ impl MBeanClientTrait for MBeanClient {
               S2: Into<String>,
     {
         let name = self.jvm.create_instance(
-            JMX_OBJECT_NAME, &vec![InvocationArg::from(name.into())]
+            JMX_OBJECT_NAME, &vec![InvocationArg::try_from(name.into())?]
         ).with_context(|_| ErrorKind::JavaCreateInstance(JMX_OBJECT_NAME))?;
         let query = self.jvm.create_instance(
-            JMX_OBJECT_NAME, &vec![InvocationArg::from(query.into())]
+            JMX_OBJECT_NAME, &vec![InvocationArg::try_from(query.into())?]
         ).with_context(|_| ErrorKind::JavaCreateInstance(JMX_OBJECT_NAME))?;
         let query = self.jvm.cast(&query, JMX_QUERY_EXP)
             .with_context(|_| ErrorKind::JavaCast(JMX_QUERY_EXP.to_string()))?;


### PR DESCRIPTION
Hello, @stefano-pogliani !
I migrated jmx-rust to j4rs 0.11.2, had to tweak the code a little bit to match the new API, but nothing major.

Will it be possible for you to release a new version? We need it in our project.
Thanks a lot in advance!